### PR TITLE
Expose prometheus metrics for minimal-relay-chain node in collators 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3816,6 +3816,7 @@ dependencies = [
  "sp-consensus",
  "sp-consensus-babe",
  "sp-runtime",
+ "substrate-prometheus-endpoint",
  "tracing",
 ]
 

--- a/cumulus/client/relay-chain-minimal-node/Cargo.toml
+++ b/cumulus/client/relay-chain-minimal-node/Cargo.toml
@@ -23,6 +23,7 @@ sc-authority-discovery = { path = "../../../substrate/client/authority-discovery
 sc-network = { path = "../../../substrate/client/network" }
 sc-network-common = { path = "../../../substrate/client/network/common" }
 sc-service = { path = "../../../substrate/client/service" }
+substrate-prometheus-endpoint = { path = "../../../substrate/utils/prometheus" }
 sc-tracing = { path = "../../../substrate/client/tracing" }
 sc-utils = { path = "../../../substrate/client/utils" }
 sp-api = { path = "../../../substrate/primitives/api" }

--- a/cumulus/client/relay-chain-minimal-node/src/collator_overseer.rs
+++ b/cumulus/client/relay-chain-minimal-node/src/collator_overseer.rs
@@ -43,7 +43,6 @@ use polkadot_primitives::CollatorPair;
 use sc_authority_discovery::Service as AuthorityDiscoveryService;
 use sc_network::NetworkStateInfo;
 use sc_service::TaskManager;
-use sp_runtime::traits::Block as BlockT;
 
 use cumulus_primitives_core::relay_chain::{Block, Hash as PHash};
 use cumulus_relay_chain_interface::RelayChainError;
@@ -209,8 +208,6 @@ pub struct NewMinimalNode {
 	pub task_manager: TaskManager,
 	/// Overseer handle to interact with subsystems
 	pub overseer_handle: Handle,
-	/// Network service
-	pub network: Arc<sc_network::NetworkService<Block, <Block as BlockT>::Hash>>,
 }
 
 /// Glues together the [`Overseer`] and `BlockchainEvents` by forwarding

--- a/cumulus/client/relay-chain-minimal-node/src/lib.rs
+++ b/cumulus/client/relay-chain-minimal-node/src/lib.rs
@@ -32,10 +32,10 @@ use polkadot_primitives::CollatorPair;
 
 use sc_authority_discovery::Service as AuthorityDiscoveryService;
 use sc_network::{config::FullNetworkConfiguration, Event, NetworkEventStream, NetworkService};
-use sc_service::{Configuration, TaskManager};
+use sc_service::{config::PrometheusConfig, Configuration, TaskManager};
 use sp_runtime::{app_crypto::Pair, traits::Block as BlockT};
 
-use futures::StreamExt;
+use futures::{FutureExt, StreamExt};
 use std::sync::Arc;
 
 mod blockchain_rpc_client;
@@ -69,7 +69,7 @@ fn build_authority_discovery_service<Block: BlockT>(
 			..Default::default()
 		},
 		client,
-		network.clone(),
+		network,
 		Box::pin(dht_event_stream),
 		authority_discovery_role,
 		prometheus_registry,
@@ -160,12 +160,16 @@ async fn new_minimal_relay_chain(
 	let role = config.role.clone();
 	let mut net_config = sc_network::config::FullNetworkConfiguration::new(&config.network);
 
-	let task_manager = {
-		let registry = config.prometheus_config.as_ref().map(|cfg| &cfg.registry);
-		TaskManager::new(config.tokio_handle.clone(), registry)?
-	};
+	let prometheus_registry = config.prometheus_registry();
+	let task_manager = TaskManager::new(config.tokio_handle.clone(), prometheus_registry)?;
 
-	let prometheus_registry = config.prometheus_registry().cloned();
+	if let Some(PrometheusConfig { port, registry }) = config.prometheus_config.clone() {
+		task_manager.spawn_handle().spawn(
+			"prometheus-endpoint",
+			None,
+			substrate_prometheus_endpoint::init_prometheus(port, registry).map(drop),
+		);
+	}
 
 	let genesis_hash = relay_chain_rpc_client
 		.block_get_hash(Some(0))
@@ -203,18 +207,18 @@ async fn new_minimal_relay_chain(
 		relay_chain_rpc_client.clone(),
 		&config,
 		network.clone(),
-		prometheus_registry.clone(),
+		prometheus_registry.cloned(),
 	);
 
 	let overseer_args = CollatorOverseerGenArgs {
 		runtime_client: relay_chain_rpc_client.clone(),
-		network_service: network.clone(),
+		network_service: network,
 		sync_oracle,
 		authority_discovery_service,
 		collation_req_receiver_v1,
 		collation_req_receiver_vstaging,
 		available_data_req_receiver,
-		registry: prometheus_registry.as_ref(),
+		registry: prometheus_registry,
 		spawner: task_manager.spawn_handle(),
 		collator_pair,
 		req_protocol_names: request_protocol_names,
@@ -226,7 +230,7 @@ async fn new_minimal_relay_chain(
 
 	network_starter.start_network();
 
-	Ok(NewMinimalNode { task_manager, overseer_handle, network })
+	Ok(NewMinimalNode { task_manager, overseer_handle })
 }
 
 fn build_request_response_protocol_receivers(


### PR DESCRIPTION
A cherry-pick from the upstream.

Until now prometheus metrics were not exposed by the minimal relay chain node.
Also slight cleanups.
