### PR TITLE
add cli param keys_limit

### DIFF
--- a/substrate/utils/frame/benchmarking-cli/src/storage/cmd.rs
+++ b/substrate/utils/frame/benchmarking-cli/src/storage/cmd.rs
@@ -121,6 +121,11 @@ pub struct StorageParams {
 	/// (All keys if not define)
 	#[arg(long)]
 	pub keys_limit: Option<usize>,
+
+	/// Seed to use for benchs randomness, the same seed allow to replay
+	/// becnhamrks under the same conditions.
+	#[arg(long)]
+	pub random_seed: Option<u64>,
 }
 
 impl StorageCmd {
@@ -197,11 +202,13 @@ impl StorageCmd {
 	{
 		let hash = client.usage_info().chain.best_hash;
 		let mut keys: Vec<_> = if let Some(keys_limit) = self.params.keys_limit {
-			client.storage_keys(hash, None, None)?.take(keys_limit).collect()
+			use  sp_core::blake2_256;
+			let first_key = self.params.random_seed.map(|seed| sp_storage::StorageKey(blake2_256(&seed.to_be_bytes()[..]).to_vec()));
+			client.storage_keys(hash, None, first_key.as_ref())?.take(keys_limit).collect()
 		} else {
 			client.storage_keys(hash, None, None)?.collect()
 		};
-		let (mut rng, _) = new_rng(None);
+		let (mut rng, _) = new_rng(self.params.random_seed);
 		keys.shuffle(&mut rng);
 
 		for i in 0..self.params.warmups {

--- a/substrate/utils/frame/benchmarking-cli/src/storage/cmd.rs
+++ b/substrate/utils/frame/benchmarking-cli/src/storage/cmd.rs
@@ -116,6 +116,11 @@ pub struct StorageParams {
 	/// Include child trees in benchmark.
 	#[arg(long)]
 	pub include_child_trees: bool,
+
+	/// Maximum number of keys to read
+	/// (All keys if not define)
+	#[arg(long)]
+	pub keys_limit: Option<usize>,
 }
 
 impl StorageCmd {
@@ -191,7 +196,11 @@ impl StorageCmd {
 		BA: ClientBackend<B>,
 	{
 		let hash = client.usage_info().chain.best_hash;
-		let mut keys: Vec<_> = client.storage_keys(hash, None, None)?.collect();
+		let mut keys: Vec<_> = if let Some(keys_limit) = self.params.keys_limit {
+			client.storage_keys(hash, None, None)?.take(keys_limit).collect()
+		} else {
+			client.storage_keys(hash, None, None)?.collect()
+		};
 		let (mut rng, _) = new_rng(None);
 		keys.shuffle(&mut rng);
 

--- a/substrate/utils/frame/benchmarking-cli/src/storage/read.rs
+++ b/substrate/utils/frame/benchmarking-cli/src/storage/read.rs
@@ -40,8 +40,12 @@ impl StorageCmd {
 		let best_hash = client.usage_info().chain.best_hash;
 
 		info!("Preparing keys from block {}", best_hash);
-		// Load all keys and randomly shuffle them.
-		let mut keys: Vec<_> = client.storage_keys(best_hash, None, None)?.collect();
+		// Load keys and randomly shuffle them.
+		let mut keys: Vec<_> = if let Some(keys_limit) = self.params.keys_limit {
+			client.storage_keys(best_hash, None, None)?.take(keys_limit).collect()
+		} else {
+			client.storage_keys(best_hash, None, None)?.collect()
+		};
 		let (mut rng, _) = new_rng(None);
 		keys.shuffle(&mut rng);
 

--- a/substrate/utils/frame/benchmarking-cli/src/storage/read.rs
+++ b/substrate/utils/frame/benchmarking-cli/src/storage/read.rs
@@ -42,11 +42,13 @@ impl StorageCmd {
 		info!("Preparing keys from block {}", best_hash);
 		// Load keys and randomly shuffle them.
 		let mut keys: Vec<_> = if let Some(keys_limit) = self.params.keys_limit {
-			client.storage_keys(best_hash, None, None)?.take(keys_limit).collect()
+			use  sp_core::blake2_256;
+			let first_key = self.params.random_seed.map(|seed| sp_storage::StorageKey(blake2_256(&seed.to_be_bytes()[..]).to_vec()));
+			client.storage_keys(best_hash, None, first_key.as_ref())?.take(keys_limit).collect()
 		} else {
 			client.storage_keys(best_hash, None, None)?.collect()
 		};
-		let (mut rng, _) = new_rng(None);
+		let (mut rng, _) = new_rng(self.params.random_seed);
 		keys.shuffle(&mut rng);
 
 		let mut child_nodes = Vec::new();

--- a/substrate/utils/frame/benchmarking-cli/src/storage/write.rs
+++ b/substrate/utils/frame/benchmarking-cli/src/storage/write.rs
@@ -62,11 +62,14 @@ impl StorageCmd {
 		info!("Preparing keys from block {}", best_hash);
 		// Load KV pairs and randomly shuffle them.
 		let mut kvs: Vec<_> = if let Some(keys_limit) = self.params.keys_limit {
-			trie.pairs(Default::default())?.take(keys_limit).collect()
+			let start_at = self.params.random_seed.map(|seed| sp_core::blake2_256(&seed.to_be_bytes()[..]).to_vec());
+			let mut iter_args = sp_state_machine::IterArgs::default();
+			iter_args.start_at = start_at.as_deref();
+			trie.pairs(iter_args)?.take(keys_limit).collect()
 		} else {
 			trie.pairs(Default::default())?.collect()
 		};
-		let (mut rng, _) = new_rng(None);
+		let (mut rng, _) = new_rng(self.params.random_seed);
 		kvs.shuffle(&mut rng);
 		info!("Writing {} keys", kvs.len());
 

--- a/substrate/utils/frame/benchmarking-cli/src/storage/write.rs
+++ b/substrate/utils/frame/benchmarking-cli/src/storage/write.rs
@@ -60,8 +60,12 @@ impl StorageCmd {
 		let trie = DbStateBuilder::<Block>::new(storage.clone(), original_root).build();
 
 		info!("Preparing keys from block {}", best_hash);
-		// Load all KV pairs and randomly shuffle them.
-		let mut kvs: Vec<_> = trie.pairs(Default::default())?.collect();
+		// Load KV pairs and randomly shuffle them.
+		let mut kvs: Vec<_> = if let Some(keys_limit) = self.params.keys_limit {
+			trie.pairs(Default::default())?.take(keys_limit).collect()
+		} else {
+			trie.pairs(Default::default())?.collect()
+		};
 		let (mut rng, _) = new_rng(None);
 		kvs.shuffle(&mut rng);
 		info!("Writing {} keys", kvs.len());


### PR DESCRIPTION
Add a command line option `--keys-limit` that limit the number of keys to read/write on storage benchmarks