### PR TITLE
Pallet parameters account for all parameters read weight

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11132,6 +11132,7 @@ dependencies = [
 name = "pallet-parameters"
 version = "0.1.0"
 dependencies = [
+ "cumulus-primitives-storage-weight-reclaim",
  "docify",
  "frame-benchmarking",
  "frame-support",

--- a/substrate/frame/parameters/Cargo.toml
+++ b/substrate/frame/parameters/Cargo.toml
@@ -19,6 +19,7 @@ frame-system = { path = "../system", default-features = false }
 sp-core = { path = "../../primitives/core", default-features = false }
 sp-runtime = { path = "../../primitives/runtime", default-features = false }
 sp-std = { path = "../../primitives/std", default-features = false }
+cumulus-primitives-storage-weight-reclaim = { path = "../../../cumulus/primitives/storage-weight-reclaim", default-features = false}
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true }
 
 [dev-dependencies]
@@ -39,6 +40,7 @@ std = [
 	"sp-core/std",
 	"sp-runtime/std",
 	"sp-std/std",
+	"cumulus-primitives-storage-weight-reclaim/std",
 ]
 runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",

--- a/substrate/frame/parameters/src/lib.rs
+++ b/substrate/frame/parameters/src/lib.rs
@@ -198,7 +198,7 @@ pub mod pallet {
 	/// Since we account for all parameters read weight for each block,
 	/// don't double count it in other pallet benchmarks
 	#[pallet::storage]
-	#[pallet::whitelist_storage]
+	// #[pallet::whitelist_storage]
 	pub type Parameters<T: Config> =
 		StorageMap<_, Blake2_128Concat, KeyOf<T>, ValueOf<T>, OptionQuery>;
 

--- a/substrate/frame/parameters/src/lib.rs
+++ b/substrate/frame/parameters/src/lib.rs
@@ -202,12 +202,7 @@ pub mod pallet {
 	}
 
 	/// Stored parameters.
-	///
-	/// ## Storage Whitelist
-	/// Since we account for all parameters read weight for each block,
-	/// don't double count it in other pallet benchmarks
 	#[pallet::storage]
-	// #[pallet::whitelist_storage]
 	pub type Parameters<T: Config> =
 		StorageMap<_, Blake2_128Concat, KeyOf<T>, ValueOf<T>, OptionQuery>;
 

--- a/substrate/frame/parameters/src/lib.rs
+++ b/substrate/frame/parameters/src/lib.rs
@@ -193,7 +193,12 @@ pub mod pallet {
 	}
 
 	/// Stored parameters.
+	/// 
+	/// ## Storage Whitelist
+	/// Since we account for all parameters read weight for each block,
+	/// don't double count it in other pallet benchmarks
 	#[pallet::storage]
+	#[pallet::whitelist_storage]
 	pub type Parameters<T: Config> =
 		StorageMap<_, Blake2_128Concat, KeyOf<T>, ValueOf<T>, OptionQuery>;
 

--- a/substrate/frame/parameters/src/lib.rs
+++ b/substrate/frame/parameters/src/lib.rs
@@ -179,9 +179,8 @@ pub mod pallet {
 
 			let proof_size_diff = proof_size_after.saturating_sub(proof_size_before);
 
-			Weight::zero()
+			Weight::from_parts(0, proof_size_diff)
 				.saturating_add(T::DbWeight::get().reads(items))
-				.saturating_add(Weight::from_parts(0, proof_size_diff))
 		}
 	}
 

--- a/substrate/frame/parameters/src/lib.rs
+++ b/substrate/frame/parameters/src/lib.rs
@@ -167,6 +167,15 @@ pub mod pallet {
 		type WeightInfo: WeightInfo;
 	}
 
+	#[pallet::hooks]
+	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+		fn on_initialize(_: BlockNumberFor<T>) -> Weight {
+			let items = Parameters::<T>::iter().count() as u64;
+
+			Weight::zero().saturating_add(T::DbWeight::get().reads(items))
+		}
+	}
+
 	#[pallet::event]
 	#[pallet::generate_deposit(pub(crate) fn deposit_event)]
 	pub enum Event<T: Config> {


### PR DESCRIPTION
Account for all parameters read weight on every block, and whitelist the parameters storage so the weight is not double counted.