### PR TITLE
Fix: Pallet Treasury benchmarks seed creates conflicting zero address

### DIFF
--- a/substrate/frame/treasury/src/benchmarking.rs
+++ b/substrate/frame/treasury/src/benchmarking.rs
@@ -57,7 +57,7 @@ where
 	}
 }
 
-const SEED: u32 = 0;
+const SEED: u32 = 1;
 
 // Create the pre-requisite information needed to create a treasury `spend_local`.
 fn setup_proposal<T: Config<I>, I: 'static>(


### PR DESCRIPTION
The beneficiary address generated by the `pallet-treasury` benchmarks conflicts with the `ERC20` contracts which prevent transfers to the zero address.

Required by https://github.com/moonbeam-foundation/moonbeam/pull/3220