### PR TITLE
state_traceBlock: replay block without final checks

### DIFF
--- a/polkadot/node/service/src/fake_runtime_api.rs
+++ b/polkadot/node/service/src/fake_runtime_api.rs
@@ -68,6 +68,10 @@ sp_api::impl_runtime_apis! {
 			unimplemented!()
 		}
 
+		fn execute_block_without_final_checks(_: Block) {
+			unimplemented!()
+		}
+
 		fn initialize_block(_: &<Block as BlockT>::Header) -> sp_runtime::ExtrinsicInclusionMode {
 			unimplemented!()
 		}

--- a/polkadot/runtime/rococo/src/lib.rs
+++ b/polkadot/runtime/rococo/src/lib.rs
@@ -1859,6 +1859,10 @@ sp_api::impl_runtime_apis! {
 			Executive::execute_block(block);
 		}
 
+		fn execute_block_without_final_checks(block: Block) {
+			Executive::execute_block_without_final_checks(block)
+		}
+
 		fn initialize_block(header: &<Block as BlockT>::Header) -> sp_runtime::ExtrinsicInclusionMode {
 			Executive::initialize_block(header)
 		}

--- a/polkadot/runtime/westend/src/lib.rs
+++ b/polkadot/runtime/westend/src/lib.rs
@@ -1938,6 +1938,10 @@ sp_api::impl_runtime_apis! {
 			Executive::execute_block(block);
 		}
 
+		fn execute_block_without_final_checks(block: Block) {
+			Executive::execute_block_without_final_checks(block)
+		}
+
 		fn initialize_block(header: &<Block as BlockT>::Header) -> sp_runtime::ExtrinsicInclusionMode {
 			Executive::initialize_block(header)
 		}

--- a/substrate/client/tracing/src/block/mod.rs
+++ b/substrate/client/tracing/src/block/mod.rs
@@ -232,8 +232,8 @@ where
 				self
 					.client
 					.runtime_api()
-					.execute_block_without_final_checks(parent_hash, block.clone())
-					.or_else(|_| self.client.runtime_api().execute_block(parent_hash, block))
+					.execute_block(parent_hash, block.clone())
+					.or_else(|_| self.client.runtime_api().execute_block_without_final_checks(parent_hash, block))
 			}) {
 				return Err(Error::Dispatch(format!(
 					"Failed to collect traces and execute block: {}",

--- a/substrate/client/tracing/src/block/mod.rs
+++ b/substrate/client/tracing/src/block/mod.rs
@@ -227,7 +227,13 @@ where
 			if let Err(e) = dispatcher::with_default(&dispatch, || {
 				let span = tracing::info_span!(target: TRACE_TARGET, "trace_block");
 				let _enter = span.enter();
-				self.client.runtime_api().execute_block(parent_hash, block)
+
+				// Execute block without final checks if possible
+				self
+					.client
+					.runtime_api()
+					.execute_block_without_final_checks(parent_hash, block.clone())
+					.or_else(|_| self.client.runtime_api().execute_block(parent_hash, block))
 			}) {
 				return Err(Error::Dispatch(format!(
 					"Failed to collect traces and execute block: {}",

--- a/substrate/primitives/api/src/lib.rs
+++ b/substrate/primitives/api/src/lib.rs
@@ -818,6 +818,8 @@ decl_runtime_apis! {
 		fn version() -> RuntimeVersion;
 		/// Execute the given block.
 		fn execute_block(block: Block);
+		/// Execute the given block without final checks.
+		fn execute_block_without_final_checks(block: Block);
 		/// Initialize a block with the given header.
 		#[changed_in(5)]
 		#[renamed("initialise_block", 2)]

--- a/substrate/utils/frame/benchmarking-cli/src/overhead/fake_runtime_api.rs
+++ b/substrate/utils/frame/benchmarking-cli/src/overhead/fake_runtime_api.rs
@@ -47,6 +47,10 @@ sp_api::impl_runtime_apis! {
 			unimplemented!()
 		}
 
+		fn execute_block_without_final_checks(_: Block) {
+			unimplemented!()
+		}
+
 		fn initialize_block(_: &<Block as BlockT>::Header) -> sp_runtime::ExtrinsicInclusionMode {
 			unimplemented!()
 		}


### PR DESCRIPTION
For some reason, `state_traceBlock` replays the block with discrepancies that cause a mismatch in the storage root (and the intermediate storage root in the Frontier digest item).

We don’t perform these final checks for ethereum tracing, so it makes sense to skip them for Substrate tracing as well.