### PR TITLE
state_traceBlock: enable proof recording

### DIFF
--- a/substrate/client/tracing/Cargo.toml
+++ b/substrate/client/tracing/Cargo.toml
@@ -48,6 +48,8 @@ sp-runtime.workspace = true
 sp-runtime.default-features = true
 sp-tracing.workspace = true
 sp-tracing.default-features = true
+sp-trie.workspace = true
+sp-trie.default-features = true
 
 [dev-dependencies]
 criterion = { workspace = true, default-features = true }

--- a/substrate/client/tracing/src/block/mod.rs
+++ b/substrate/client/tracing/src/block/mod.rs
@@ -35,7 +35,7 @@ use tracing::{
 
 use crate::{SpanDatum, TraceEvent, Values};
 use sc_client_api::BlockBackend;
-use sp_api::{Core, Metadata, ProvideRuntimeApi};
+use sp_api::{ApiExt, Core, Metadata, ProvideRuntimeApi};
 use sp_blockchain::HeaderBackend;
 use sp_core::hexdisplay::HexDisplay;
 use sp_rpc::tracing::{BlockTrace, Span, TraceBlockResponse};
@@ -44,6 +44,7 @@ use sp_runtime::{
 	traits::{Block as BlockT, Header},
 };
 use sp_tracing::{WASM_NAME_KEY, WASM_TARGET_KEY, WASM_TRACE_IDENTIFIER};
+use sp_trie::proof_size_extension::ProofSizeExt;
 
 // Default to only pallet, frame support and state related traces
 const DEFAULT_TARGETS: &str = "pallet,frame,state";
@@ -227,7 +228,17 @@ where
 			if let Err(e) = dispatcher::with_default(&dispatch, || {
 				let span = tracing::info_span!(target: TRACE_TARGET, "trace_block");
 				let _enter = span.enter();
-				self.client.runtime_api().execute_block(parent_hash, block)
+
+				// Enable proof recording
+				let mut runtime_api = self.client.runtime_api();
+				runtime_api.record_proof();
+				let recorder = runtime_api
+					.proof_recorder()
+					.expect("Proof recording is enabled in the line above; qed.");
+				runtime_api.register_extension(ProofSizeExt::new(recorder));
+
+				// Replay block with proof recording
+				runtime_api.execute_block(parent_hash, block)
 			}) {
 				return Err(Error::Dispatch(format!(
 					"Failed to collect traces and execute block: {}",
@@ -267,6 +278,9 @@ where
 			.map(|s| s.into())
 			.collect();
 		tracing::debug!(target: "state_tracing", "Captured {} spans and {} events", spans.len(), events.len());
+
+		// Extract the proof (might not be needed)
+		let _proof = self.client.runtime_api().extract_proof();
 
 		Ok(TraceBlockResponse::BlockTrace(BlockTrace {
 			block_hash: block_id_as_string(BlockId::<Block>::Hash(self.block)),


### PR DESCRIPTION
Enable proof recording when we replay the block with `state_traceBlock`.

More context from this github comment: https://github.com/moonbeam-foundation/polkadot-sdk/pull/19#pullrequestreview-2916182813