### PR TITLE
Add `force-xcm-processor` cargo feature to Westend runtime

### DIFF
--- a/polkadot/runtime/westend/Cargo.toml
+++ b/polkadot/runtime/westend/Cargo.toml
@@ -229,6 +229,7 @@ std = [
 	"xcm-runtime-apis/std",
 	"xcm/std",
 ]
+force-xcm-processor = []
 runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",
 	"frame-election-provider-support/runtime-benchmarks",

--- a/polkadot/runtime/westend/src/lib.rs
+++ b/polkadot/runtime/westend/src/lib.rs
@@ -1458,11 +1458,11 @@ impl pallet_message_queue::Config for Runtime {
 	type MaxStale = MessageQueueMaxStale;
 	type ServiceWeight = MessageQueueServiceWeight;
 	type IdleMaxServiceWeight = MessageQueueServiceWeight;
-	#[cfg(not(feature = "runtime-benchmarks"))]
-	type MessageProcessor = MessageProcessor;
-	#[cfg(feature = "runtime-benchmarks")]
+	#[cfg(all(feature = "runtime-benchmarks", not(feature = "force-xcm-processor")))]
 	type MessageProcessor =
 		pallet_message_queue::mock_helpers::NoopMessageProcessor<AggregateMessageOrigin>;
+	#[cfg(any(not(feature = "runtime-benchmarks"), feature = "force-xcm-processor"))]
+	type MessageProcessor = MessageProcessor;
 	type QueueChangeHandler = ParaInclusion;
 	type QueuePausedQuery = ();
 	type WeightInfo = weights::pallet_message_queue::WeightInfo<Runtime>;
@@ -2135,7 +2135,7 @@ mod benches {
 		[frame_system, SystemBench::<Runtime>]
 		[frame_system_extensions, SystemExtensionsBench::<Runtime>]
 		[pallet_timestamp, Timestamp]
-		[pallet_transaction_payment, TransactionPayment]
+		[pallet_transaction_payment, TransactionPaymentBench::<Runtime>]
 		[pallet_treasury, Treasury]
 		[pallet_utility, Utility]
 		[pallet_vesting, Vesting]
@@ -2818,6 +2818,7 @@ sp_api::impl_runtime_apis! {
 			use frame_system_benchmarking::Pallet as SystemBench;
 			use frame_system_benchmarking::extensions::Pallet as SystemExtensionsBench;
 			use pallet_nomination_pools_benchmarking::Pallet as NominationPoolsBench;
+			use pallet_transaction_payment::benchmarking::Pallet as TransactionPaymentBench;
 
 			type XcmBalances = pallet_xcm_benchmarks::fungible::Pallet::<Runtime>;
 			type XcmGeneric = pallet_xcm_benchmarks::generic::Pallet::<Runtime>;
@@ -2848,6 +2849,7 @@ sp_api::impl_runtime_apis! {
 			use frame_system_benchmarking::Pallet as SystemBench;
 			use frame_system_benchmarking::extensions::Pallet as SystemExtensionsBench;
 			use pallet_nomination_pools_benchmarking::Pallet as NominationPoolsBench;
+			use pallet_transaction_payment::benchmarking::Pallet as TransactionPaymentBench;
 
 			impl pallet_session_benchmarking::Config for Runtime {}
 			impl pallet_offences_benchmarking::Config for Runtime {}
@@ -2922,6 +2924,7 @@ sp_api::impl_runtime_apis! {
 					}
 				}
 			}
+			impl pallet_transaction_payment::benchmarking::Config for Runtime {}
 			impl frame_system_benchmarking::Config for Runtime {}
 			impl pallet_nomination_pools_benchmarking::Config for Runtime {}
 			impl polkadot_runtime_parachains::disputes::slashing::benchmarking::Config for Runtime {}


### PR DESCRIPTION
### Summary

 This PR introduces a new force-xcm-processor cargo feature for the Westend runtime that allows using the real XCM MessageProcessor even when the runtime-benchmarks feature is enabled.
 It also fixes the pallet_transaction_payment benchmarking setup.

 ### Changes

 New force-xcm-processor feature (polkadot/runtime/westend/Cargo.toml)
 - Adds an empty force-xcm-processor feature flag.

 Conditional MessageProcessor selection (polkadot/runtime/westend/src/lib.rs)
 - Previously, runtime-benchmarks always forced NoopMessageProcessor. Now:
     - NoopMessageProcessor is used only when runtime-benchmarks is enabled and force-xcm-processor is not set.
     - The real MessageProcessor is used when benchmarks are disabled or when force-xcm-processor is explicitly enabled.
 - This gives developers control to run benchmarks with the actual XCM processor when needed.

 Fix pallet_transaction_payment benchmarking
 - Updates the benchmark list to use the proper TransactionPaymentBench::<Runtime> wrapper instead of the raw TransactionPayment pallet.
 - Adds the required use pallet_transaction_payment::benchmarking::Pallet as TransactionPaymentBench import in both benchmark_metadata and dispatch_benchmark.
 - Implements pallet_transaction_payment::benchmarking::Config for Runtime.

 ### Motivation

 When running integration tests or specific XCM-related benchmarks, the NoopMessageProcessor mock can hide real behavior. The force-xcm-processor feature provides an escape hatch to opt
 into the real processor while still compiling with benchmark support.